### PR TITLE
Add main menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     src/Material.cpp
     src/Weapon.cpp
     src/Shop.cpp
+    src/Menu.cpp
 )
 
 set(HEADERS
@@ -35,6 +36,7 @@ set(HEADERS
     src/Material.h
     src/Weapon.h
     src/Shop.h
+    src/Menu.h
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A Brotato-inspired top-down survival shooter game built with C++ and SDL2.
 - **Brotato-Style UI**: Health bar, level display, materials counter, and countdown timer
 - **Materials System**: Earn materials by killing enemies
 - **Character Stats**: Speed, damage, pickup range, armor, health regen, and more
+- **Main Menu System**: Navigate with keyboard/mouse, ESC to pause during gameplay
+- **Shop System**: Wave-end purchasing interface with material-based economy
 
 ## 🛠️ Prerequisites
 
@@ -66,6 +68,8 @@ Your project should look like this:
 potatogame/
 ├── CMakeLists.txt
 ├── README.md
+├── vcpkg.json
+├── build-macos.sh
 ├── src/
 │   ├── main.cpp
 │   ├── Game.cpp
@@ -74,12 +78,31 @@ potatogame/
 │   ├── Player.h
 │   ├── Enemy.cpp
 │   ├── Enemy.h
+│   ├── SlimeEnemy.cpp
+│   ├── SlimeEnemy.h
+│   ├── PebblinEnemy.cpp
+│   ├── PebblinEnemy.h
 │   ├── Bullet.cpp
 │   ├── Bullet.h
 │   ├── Vector2.cpp
 │   ├── Vector2.h
 │   ├── ExperienceOrb.cpp
-│   └── ExperienceOrb.h
+│   ├── ExperienceOrb.h
+│   ├── Material.cpp
+│   ├── Material.h
+│   ├── Weapon.cpp
+│   ├── Weapon.h
+│   ├── Shop.cpp
+│   ├── Shop.h
+│   ├── Menu.cpp
+│   └── Menu.h
+├── assets/
+│   ├── fonts/
+│   │   └── default.ttf
+│   ├── character/
+│   ├── enemies/
+│   ├── weapons/
+│   └── ui/
 └── monsters/
     └── landmonster/
         └── Transparent PNG/
@@ -121,13 +144,19 @@ potatogame/
 - **Movement**: WASD or Arrow Keys
 - **Aiming**: Move your mouse cursor
 - **Shooting**: Spacebar (hold for continuous fire)
+- **Menu Navigation**: Arrow Keys + Enter, or mouse click
+- **Pause Game**: ESC key (during gameplay)
+- **Shop**: Automatically opens at end of each wave
 
 ### Gameplay
-1. **Survive the Waves**: Each wave lasts 20-60 seconds
-2. **Kill Enemies**: Shoot the blue monsters that spawn from screen edges
-3. **Collect Experience**: Walk over green glowing orbs to gain XP
-4. **Level Up**: Automatically gain stats when you have enough XP
-5. **Earn Materials**: Get materials for each enemy killed
+1. **Start from Menu**: Use main menu to begin new game
+2. **Survive the Waves**: Each wave lasts 20-60 seconds
+3. **Kill Enemies**: Shoot the blue monsters that spawn from screen edges
+4. **Collect Experience**: Walk over green glowing orbs to gain XP
+5. **Level Up**: Automatically gain stats when you have enough XP
+6. **Earn Materials**: Get materials for each enemy killed
+7. **Shop Between Waves**: Purchase weapons and upgrades with materials
+8. **Pause Anytime**: Press ESC to pause and access menu options
 
 ### UI Elements
 - **Top-Left Red Bar**: Your health (X / Y format)
@@ -188,16 +217,20 @@ potatogame/
 ## 📋 System Requirements
 
 ### Minimum Requirements
-- **OS**: Windows 10/11
+- **OS**: Windows 10/11 or macOS 12.0+
 - **CPU**: Any modern CPU (game is not CPU-intensive)
 - **RAM**: 100MB available memory
 - **Graphics**: Any GPU with basic 2D acceleration
 - **Storage**: ~50MB for game files and dependencies
 
 ### Recommended
-- **Resolution**: 1024x768 or higher
-- **Mouse**: For precise aiming
+- **Resolution**: 1024x768 or higher (works great on Retina displays)
+- **Mouse**: For precise aiming and menu navigation
 - **Audio**: Speakers/headphones (if audio is added later)
+
+### Platform-Specific
+- **Windows**: Visual Studio 2019/2022 with C++ tools
+- **macOS**: Xcode Command Line Tools, works on both Intel and Apple Silicon
 
 ## 📞 Support
 
@@ -210,95 +243,153 @@ If you encounter issues:
 
 ## 🎯 Quick Start Checklist
 
+### Windows
 - [ ] Visual Studio installed with C++ tools
 - [ ] vcpkg installed and integrated
 - [ ] SDL2 and SDL2_image installed via vcpkg
 - [ ] Project files downloaded/cloned
-- [ ] Monster sprite assets in correct location
 - [ ] Built successfully with CMake
 - [ ] Game runs and displays UI correctly
+
+### macOS
+- [ ] Xcode Command Line Tools installed
+- [ ] Homebrew, CMake, and Ninja installed
+- [ ] vcpkg cloned and bootstrapped
+- [ ] Project files downloaded/cloned
+- [ ] Built successfully with `./build-macos.sh`
+- [ ] Game runs and displays UI correctly
+
+### Both Platforms
+- [ ] Monster sprite assets in correct location
+- [ ] Main menu appears on startup
+- [ ] Menu navigation works (keyboard/mouse)
+- [ ] ESC key pauses game correctly
+- [ ] Shop opens at end of waves
 
 Once all items are checked, you should be able to enjoy the game! 🎮
 
 ---
 
-**Version**: 1.0  
+**Version**: 1.1  
 **Last Updated**: December 2024  
-**Compatible**: Windows 10/11, Visual Studio 2019/2022
+**Compatible**: Windows 10/11 (Visual Studio 2019/2022), macOS 12.0+ (Intel & Apple Silicon)
+
+### Recent Updates (v1.1)
+- ✅ **Main Menu System**: Full navigation with keyboard/mouse support
+- ✅ **macOS Support**: Native builds for both Intel and Apple Silicon
+- ✅ **Enhanced Controls**: ESC pause functionality, improved mouse handling
+- ✅ **Shop System**: Wave-end purchasing with materials
+- ✅ **Multiple Enemy Types**: Slime (ranged) and Pebblin (melee) enemies
+- ✅ **Cross-Platform Assets**: TTF font support with fallback rendering
 
 ---
 
-## 🍎 macOS Setup (vcpkg + Ninja)
+## 🍎 macOS Setup Instructions
 
-### 1) Install Tools
+### Prerequisites
+
+1. **Xcode Command Line Tools** (for compiler and build tools)
+2. **Homebrew** (package manager)
+3. **Git** (for version control)
+
+### Step 1: Install Required Tools
 
 ```bash
+# Install Homebrew (if you don't have it)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Install build tools
 brew install cmake ninja
 ```
 
-### 2) Install vcpkg
+### Step 2: Install vcpkg Package Manager
 
 ```bash
+# Clone vcpkg to your home directory
 git clone https://github.com/microsoft/vcpkg.git "$HOME/vcpkg"
+
+# Bootstrap vcpkg
 "$HOME/vcpkg"/bootstrap-vcpkg.sh
 ```
 
-Note: you do NOT need to `vcpkg install ...` manually — manifest mode (`vcpkg.json`) will resolve dependencies during CMake configure.
+**Note**: You do NOT need to install SDL2 manually — the project uses manifest mode (`vcpkg.json`) which automatically resolves dependencies during build.
 
-Optional: set default triplet for convenience
-
+**Optional**: Set default triplet for convenience:
 ```bash
-# On Apple Silicon (arm64)
+# Add to your shell profile (~/.zshrc or ~/.bash_profile)
+
+# On Apple Silicon (M1/M2/M3)
 export VCPKG_DEFAULT_TRIPLET=arm64-osx
 
-# On Intel (x86_64)
+# On Intel Mac
 # export VCPKG_DEFAULT_TRIPLET=x64-osx
 ```
 
-### 3) Build with helper script (recommended)
+### Step 3: Clone/Download the Game
 
 ```bash
-cd path/to/potatogame_group3
+# Clone the repository
+git clone [your-repository-url] potatogame_group3
+cd potatogame_group3
+```
+
+### Step 4: Build the Game (Recommended Method)
+
+Use the provided build script for easy compilation:
+
+```bash
+# Make the script executable
 chmod +x ./build-macos.sh
-./build-macos.sh                      # native Debug build for your host arch
-./build-macos.sh --config Release     # native Release build
+
+# Build for Debug (default)
+./build-macos.sh
+
+# Build for Release (optimized)
+./build-macos.sh --config Release
 ```
 
-Advanced: universal build (for both arm64 and x86_64)
-
+**Advanced Options:**
 ```bash
+# Universal build (both arm64 and x86_64)
 ./build-macos.sh --arch universal --config Release
+
+# Custom vcpkg location
+./build-macos.sh --vcpkg-root "/path/to/your/vcpkg"
 ```
 
-Custom vcpkg location:
+### Step 5: Build with Raw CMake (Alternative)
 
-```bash
-./build-macos.sh --vcpkg-root "$HOME/dev/vcpkg"
-```
+If you prefer manual CMake setup:
 
-### 4) Build with raw CMake (alternative)
-
-Apple Silicon:
+**For Apple Silicon (M1/M2/M3):**
 ```bash
 cmake -G Ninja -S . -B build/macos-arm64-ninja \
   -DCMAKE_TOOLCHAIN_FILE="$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
-  -DCMAKE_OSX_ARCHITECTURES=arm64
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DCMAKE_BUILD_TYPE=Debug
+
 cmake --build build/macos-arm64-ninja
 ```
 
-Intel:
+**For Intel Mac:**
 ```bash
 cmake -G Ninja -S . -B build/macos-x64-ninja \
   -DCMAKE_TOOLCHAIN_FILE="$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
-  -DCMAKE_OSX_ARCHITECTURES=x86_64
+  -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+  -DCMAKE_BUILD_TYPE=Debug
+
 cmake --build build/macos-x64-ninja
 ```
 
-Run (from the build dir):
+### Step 6: Run the Game
 
 ```bash
+# Navigate to the build directory
+cd build/macos-arm64-ninja  # or macos-x64-ninja for Intel
+
+# Run the game
 ./BrotatoGame
 ```
 

--- a/src/Game.h
+++ b/src/Game.h
@@ -10,6 +10,7 @@
 #include "Material.h"
 #include "Weapon.h"
 #include "Shop.h"
+#include "Menu.h"
 
 // Forward declarations
 class SlimeEnemy;
@@ -19,6 +20,12 @@ enum class EnemySpawnType {
     BASE,
     SLIME,
     PEBBLIN
+};
+
+enum class GameState {
+    MENU,
+    PLAYING,
+    GAME_OVER
 };
 
 struct SpawnIndicator {
@@ -49,6 +56,11 @@ public:
     const Player* getPlayer() const { return player.get(); }
     SDL_Renderer* getRenderer() const { return renderer; }
     
+    // Game state management
+    void showMenu(bool canContinue = false);
+    void startNewGame();
+    void resetGameState();
+    
 private:
     void handleEvents();
     void update(float deltaTime);
@@ -66,6 +78,7 @@ private:
     SDL_Window* window;
     SDL_Renderer* renderer;
     bool running;
+    GameState gameState;
     
     std::unique_ptr<Player> player;
     std::vector<std::unique_ptr<Enemy>> enemies;
@@ -90,6 +103,13 @@ private:
     
     // Shop system
     std::unique_ptr<Shop> shop;
+    
+    // Menu system
+    std::unique_ptr<Menu> mainMenu;
+    
+    // ESC key cooldown for game state (to prevent rapid menu toggling)
+    float escCooldownTimer;
+    static constexpr float ESC_COOLDOWN_DURATION = 0.3f; // 300ms cooldown
     
     // TTF Font system
     TTF_Font* defaultFont;

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1,0 +1,408 @@
+#include "Menu.h"
+#include <iostream>
+#include <cstdio>
+
+Menu::Menu() : active(false), canContinue(false), optionSelected(false), 
+               currentOption(MenuOption::NEW_GAME),
+               upKeyPressed(false), downKeyPressed(false), 
+               enterKeyPressed(false), escKeyPressed(false), lastMousePressed(false),
+               titleFont(nullptr), menuFont(nullptr) {
+    
+    // Initialize colors
+    titleColor = {255, 255, 255, 255};    // White
+    normalColor = {200, 200, 200, 255};   // Light gray
+    selectedColor = {255, 255, 0, 255};   // Yellow
+    disabledColor = {100, 100, 100, 255}; // Dark gray
+    
+    // Layout settings
+    titleY = 150;
+    menuStartY = 400;
+    menuSpacing = 80;
+}
+
+Menu::~Menu() {
+    if (titleFont) {
+        TTF_CloseFont(titleFont);
+        titleFont = nullptr;
+    }
+    if (menuFont) {
+        TTF_CloseFont(menuFont);
+        menuFont = nullptr;
+    }
+}
+
+void Menu::loadAssets(SDL_Renderer* renderer) {
+    // Try to load fonts in order of preference
+    const char* fontPaths[] = {
+        "assets/fonts/default.ttf",
+        "/System/Library/Fonts/Arial.ttf",  // macOS system font
+        "/System/Library/Fonts/Helvetica.ttc",  // macOS system font
+        "C:/Windows/Fonts/arial.ttf",
+        "C:/Windows/Fonts/calibri.ttf",
+        "C:/Windows/Fonts/consola.ttf"
+    };
+    
+    titleFont = nullptr;
+    menuFont = nullptr;
+    
+    for (const char* fontPath : fontPaths) {
+        if (!titleFont) {
+            titleFont = TTF_OpenFont(fontPath, 48);
+            if (titleFont) {
+                std::cout << "Menu: Loaded title font from " << fontPath << std::endl;
+            }
+        }
+        if (!menuFont) {
+            menuFont = TTF_OpenFont(fontPath, 32);
+            if (menuFont) {
+                std::cout << "Menu: Loaded menu font from " << fontPath << std::endl;
+            }
+        }
+        
+        if (titleFont && menuFont) {
+            break;
+        }
+    }
+    
+    if (!titleFont || !menuFont) {
+        std::cout << "Menu: Using fallback text rendering (no TTF fonts available)" << std::endl;
+    }
+}
+
+bool Menu::handleInput(const Uint8* keyState, bool escAvailable) {
+    if (!active) return false;
+    
+    bool escProcessed = false;
+    
+    // Handle UP key
+    if (keyState[SDL_SCANCODE_UP] && !upKeyPressed) {
+        upKeyPressed = true;
+        
+        if (currentOption == MenuOption::NEW_GAME) {
+            if (canContinue) {
+                currentOption = MenuOption::CONTINUE;
+            } else {
+                currentOption = MenuOption::EXIT;
+            }
+        } else if (currentOption == MenuOption::EXIT) {
+            currentOption = MenuOption::NEW_GAME;
+        } else if (currentOption == MenuOption::CONTINUE) {
+            currentOption = MenuOption::EXIT;
+        }
+    } else if (!keyState[SDL_SCANCODE_UP]) {
+        upKeyPressed = false;
+    }
+    
+    // Handle DOWN key
+    if (keyState[SDL_SCANCODE_DOWN] && !downKeyPressed) {
+        downKeyPressed = true;
+        
+        if (currentOption == MenuOption::CONTINUE) {
+            currentOption = MenuOption::NEW_GAME;
+        } else if (currentOption == MenuOption::NEW_GAME) {
+            currentOption = MenuOption::EXIT;
+        } else if (currentOption == MenuOption::EXIT) {
+            if (canContinue) {
+                currentOption = MenuOption::CONTINUE;
+            } else {
+                currentOption = MenuOption::NEW_GAME;
+            }
+        }
+    } else if (!keyState[SDL_SCANCODE_DOWN]) {
+        downKeyPressed = false;
+    }
+    
+    // Handle ENTER key
+    if (keyState[SDL_SCANCODE_RETURN] && !enterKeyPressed) {
+        enterKeyPressed = true;
+        activateCurrentOption();
+    } else if (!keyState[SDL_SCANCODE_RETURN]) {
+        enterKeyPressed = false;
+    }
+    
+    // Handle ESCAPE key (acts as "Continue" if available, otherwise ignored)
+    // ESC cooldown is managed globally by Game class
+    if (keyState[SDL_SCANCODE_ESCAPE] && !escKeyPressed && escAvailable) {
+        escKeyPressed = true;
+        if (canContinue) {
+            currentOption = MenuOption::CONTINUE;
+            activateCurrentOption();
+            escProcessed = true; // ESC was actually handled
+        }
+        // If canContinue is false, ESC is ignored (escProcessed remains false)
+    } else if (!keyState[SDL_SCANCODE_ESCAPE]) {
+        escKeyPressed = false;
+    }
+    
+    return escProcessed;
+}
+
+void Menu::handleMouseInput(int mouseX, int mouseY, bool mousePressed) {
+    if (!active) return;
+    
+    // Calculate menu item positions
+    int windowWidth = 1920;  // From Game constants
+    int centerX = windowWidth / 2;
+    
+    int continueY = menuStartY;
+    int newGameY = canContinue ? menuStartY + menuSpacing : menuStartY;
+    int exitY = canContinue ? menuStartY + 2 * menuSpacing : menuStartY + menuSpacing;
+    
+    // Check mouse hover over menu items
+    int menuItemWidth = 300;
+    int menuItemHeight = 50;
+    
+    MenuOption hoveredOption = currentOption;
+    bool mouseOverButton = false;
+    
+    if (canContinue && mouseX >= centerX - menuItemWidth/2 && mouseX <= centerX + menuItemWidth/2 &&
+        mouseY >= continueY - menuItemHeight/2 && mouseY <= continueY + menuItemHeight/2) {
+        hoveredOption = MenuOption::CONTINUE;
+        mouseOverButton = true;
+    } else if (mouseX >= centerX - menuItemWidth/2 && mouseX <= centerX + menuItemWidth/2 &&
+               mouseY >= newGameY - menuItemHeight/2 && mouseY <= newGameY + menuItemHeight/2) {
+        hoveredOption = MenuOption::NEW_GAME;
+        mouseOverButton = true;
+    } else if (mouseX >= centerX - menuItemWidth/2 && mouseX <= centerX + menuItemWidth/2 &&
+               mouseY >= exitY - menuItemHeight/2 && mouseY <= exitY + menuItemHeight/2) {
+        hoveredOption = MenuOption::EXIT;
+        mouseOverButton = true;
+    }
+    
+    // Update current option only if mouse is over a button
+    if (mouseOverButton) {
+        currentOption = hoveredOption;
+    }
+    
+    // Handle mouse clicks - only activate if mouse is over a button
+    if (mousePressed && !lastMousePressed && mouseOverButton) {
+        activateCurrentOption();
+    }
+    
+    lastMousePressed = mousePressed;
+}
+
+void Menu::update(float deltaTime) {
+    // Menu doesn't need complex updates, but we keep this for consistency
+    (void)deltaTime; // Suppress unused parameter warning
+}
+
+void Menu::render(SDL_Renderer* renderer, int windowWidth, int windowHeight) {
+    if (!active) {
+        return;
+    }
+    
+    // Draw semi-transparent background overlay
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 180);
+    SDL_Rect backgroundRect = {0, 0, windowWidth, windowHeight};
+    SDL_RenderFillRect(renderer, &backgroundRect);
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_NONE);
+    
+    int centerX = windowWidth / 2;
+    
+    // Render title
+    if (titleFont) {
+        renderText(renderer, "POTATO GAME", centerX - 150, titleY, titleColor, 48);
+    } else {
+        renderFallbackText(renderer, "POTATO GAME", centerX - 100, titleY, false);
+    }
+    
+    // Render menu options with hover highlighting
+    int yPos = menuStartY;
+    int menuItemWidth = 300;
+    int menuItemHeight = 50;
+    
+    if (canContinue) {
+        bool selected = (currentOption == MenuOption::CONTINUE);
+        SDL_Color color = selected ? selectedColor : normalColor;
+        
+        // Draw highlight background for selected item
+        if (selected) {
+            SDL_SetRenderDrawColor(renderer, 50, 50, 50, 100);
+            SDL_Rect highlightRect = {centerX - menuItemWidth/2, yPos - menuItemHeight/2, menuItemWidth, menuItemHeight};
+            SDL_RenderFillRect(renderer, &highlightRect);
+            
+            // Draw border around selected item
+            SDL_SetRenderDrawColor(renderer, selectedColor.r, selectedColor.g, selectedColor.b, 255);
+            SDL_RenderDrawRect(renderer, &highlightRect);
+        }
+        
+        if (menuFont) {
+            renderText(renderer, "CONTINUE", centerX - 60, yPos, color, 32);
+        } else {
+            renderFallbackText(renderer, "CONTINUE", centerX - 60, yPos, selected);
+        }
+        yPos += menuSpacing;
+    }
+    
+    // New Game option
+    {
+        bool selected = (currentOption == MenuOption::NEW_GAME);
+        SDL_Color color = selected ? selectedColor : normalColor;
+        
+        // Draw highlight background for selected item
+        if (selected) {
+            SDL_SetRenderDrawColor(renderer, 50, 50, 50, 100);
+            SDL_Rect highlightRect = {centerX - menuItemWidth/2, yPos - menuItemHeight/2, menuItemWidth, menuItemHeight};
+            SDL_RenderFillRect(renderer, &highlightRect);
+            
+            // Draw border around selected item
+            SDL_SetRenderDrawColor(renderer, selectedColor.r, selectedColor.g, selectedColor.b, 255);
+            SDL_RenderDrawRect(renderer, &highlightRect);
+        }
+        
+        if (menuFont) {
+            renderText(renderer, "NEW GAME", centerX - 70, yPos, color, 32);
+        } else {
+            renderFallbackText(renderer, "NEW GAME", centerX - 70, yPos, selected);
+        }
+        yPos += menuSpacing;
+    }
+    
+    // Exit option
+    {
+        bool selected = (currentOption == MenuOption::EXIT);
+        SDL_Color color = selected ? selectedColor : normalColor;
+        
+        // Draw highlight background for selected item
+        if (selected) {
+            SDL_SetRenderDrawColor(renderer, 50, 50, 50, 100);
+            SDL_Rect highlightRect = {centerX - menuItemWidth/2, yPos - menuItemHeight/2, menuItemWidth, menuItemHeight};
+            SDL_RenderFillRect(renderer, &highlightRect);
+            
+            // Draw border around selected item
+            SDL_SetRenderDrawColor(renderer, selectedColor.r, selectedColor.g, selectedColor.b, 255);
+            SDL_RenderDrawRect(renderer, &highlightRect);
+        }
+        
+        if (menuFont) {
+            renderText(renderer, "EXIT", centerX - 30, yPos, color, 32);
+        } else {
+            renderFallbackText(renderer, "EXIT", centerX - 30, yPos, selected);
+        }
+    }
+    
+    // Instructions at bottom
+    if (menuFont) {
+        renderText(renderer, "Use ARROW KEYS and ENTER to navigate", 
+                  centerX - 200, windowHeight - 100, normalColor, 16);
+        if (canContinue) {
+            renderText(renderer, "Press ESC to continue game", 
+                      centerX - 120, windowHeight - 60, normalColor, 16);
+        }
+    } else {
+        renderFallbackText(renderer, "Use ARROW KEYS and ENTER", centerX - 120, windowHeight - 100, false);
+        if (canContinue) {
+            renderFallbackText(renderer, "ESC to continue", centerX - 80, windowHeight - 60, false);
+        }
+    }
+}
+
+void Menu::show(bool canContinue) {
+    this->canContinue = canContinue;
+    this->active = true;
+    this->optionSelected = false;
+    
+    // Set default selected option based on context
+    if (canContinue) {
+        currentOption = MenuOption::CONTINUE;
+    } else {
+        currentOption = MenuOption::NEW_GAME;
+    }
+}
+
+void Menu::hide() {
+    active = false;
+    optionSelected = false;
+}
+
+void Menu::selectOption(MenuOption option) {
+    currentOption = option;
+}
+
+void Menu::activateCurrentOption() {
+    optionSelected = true;
+}
+
+void Menu::renderText(SDL_Renderer* renderer, const char* text, int x, int y, 
+                     SDL_Color color, int fontSize) {
+    TTF_Font* font = (fontSize > 40) ? titleFont : menuFont;
+    if (!font) {
+        renderFallbackText(renderer, text, x, y, false);
+        return;
+    }
+    
+    SDL_Surface* textSurface = TTF_RenderText_Solid(font, text, color);
+    if (!textSurface) {
+        renderFallbackText(renderer, text, x, y, false);
+        return;
+    }
+    
+    SDL_Texture* textTexture = SDL_CreateTextureFromSurface(renderer, textSurface);
+    if (!textTexture) {
+        SDL_FreeSurface(textSurface);
+        renderFallbackText(renderer, text, x, y, false);
+        return;
+    }
+    
+    int textWidth = textSurface->w;
+    int textHeight = textSurface->h;
+    SDL_FreeSurface(textSurface);
+    
+    SDL_Rect destRect = {x, y, textWidth, textHeight};
+    SDL_RenderCopy(renderer, textTexture, nullptr, &destRect);
+    
+    SDL_DestroyTexture(textTexture);
+}
+
+void Menu::renderFallbackText(SDL_Renderer* renderer, const char* text, int x, int y, bool selected) {
+    // Enhanced fallback text rendering using rectangles with patterns
+    SDL_Color color = selected ? selectedColor : normalColor;
+    SDL_SetRenderDrawColor(renderer, color.r, color.g, color.b, 255);
+    
+    // Draw text with actual letter patterns for better visibility
+    int charWidth = 20;
+    int charHeight = 32;
+    int spacing = 4;
+    
+    for (int i = 0; text[i] != '\0'; i++) {
+        int charX = x + i * (charWidth + spacing);
+        
+        // Draw a distinctive pattern for each character
+        char c = text[i];
+        
+        // Draw the character background/outline
+        SDL_Rect bgRect = {charX, y, charWidth, charHeight};
+        SDL_RenderDrawRect(renderer, &bgRect);
+        
+        // Draw letter-specific patterns
+        if (c >= 'A' && c <= 'Z') {
+            // Draw vertical lines for capitals
+            SDL_Rect line1 = {charX + 2, y + 2, 4, charHeight - 4};
+            SDL_Rect line2 = {charX + charWidth - 6, y + 2, 4, charHeight - 4};
+            SDL_RenderFillRect(renderer, &line1);
+            SDL_RenderFillRect(renderer, &line2);
+            
+            // Draw horizontal line for middle
+            SDL_Rect hline = {charX + 2, y + charHeight/2, charWidth - 4, 3};
+            SDL_RenderFillRect(renderer, &hline);
+        } else if (c >= 'a' && c <= 'z') {
+            // Draw smaller pattern for lowercase
+            SDL_Rect smallRect = {charX + 4, y + 8, charWidth - 8, charHeight - 12};
+            SDL_RenderFillRect(renderer, &smallRect);
+        } else {
+            // Draw simple filled rectangle for other characters
+            SDL_Rect fillRect = {charX + 2, y + 2, charWidth - 4, charHeight - 4};
+            SDL_RenderFillRect(renderer, &fillRect);
+        }
+        
+        // Draw selection indicator if selected
+        if (selected) {
+            SDL_SetRenderDrawColor(renderer, 255, 255, 0, 255); // Yellow
+            SDL_Rect selRect = {charX - 2, y - 2, charWidth + 4, charHeight + 4};
+            SDL_RenderDrawRect(renderer, &selRect);
+            SDL_SetRenderDrawColor(renderer, color.r, color.g, color.b, 255);
+        }
+    }
+}

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -1,0 +1,74 @@
+#pragma once
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
+
+class Game;
+
+enum class MenuOption {
+    CONTINUE,
+    NEW_GAME,
+    EXIT
+};
+
+class Menu {
+public:
+    Menu();
+    ~Menu();
+    
+    void loadAssets(SDL_Renderer* renderer);
+    bool handleInput(const Uint8* keyState, bool escAvailable = true);
+    void handleMouseInput(int mouseX, int mouseY, bool mousePressed);
+    void update(float deltaTime);
+    void render(SDL_Renderer* renderer, int windowWidth, int windowHeight);
+    
+    // Menu state
+    bool isActive() const { return active; }
+    void setActive(bool active) { this->active = active; }
+    void show(bool canContinue = false);
+    void hide();
+    
+    // Option selection
+    MenuOption getSelectedOption() const { return currentOption; }
+    bool isOptionSelected() const { return optionSelected; }
+    void resetSelection() { optionSelected = false; }
+    
+    // Menu visibility configuration
+    void setCanContinue(bool canContinue) { this->canContinue = canContinue; }
+    
+private:
+    void renderText(SDL_Renderer* renderer, const char* text, int x, int y, 
+                   SDL_Color color, int fontSize = 24);
+    void renderFallbackText(SDL_Renderer* renderer, const char* text, int x, int y, 
+                           bool selected = false);
+    void selectOption(MenuOption option);
+    void activateCurrentOption();
+    
+    bool active;
+    bool canContinue;
+    bool optionSelected;
+    MenuOption currentOption;
+    
+    // Input handling
+    bool upKeyPressed;
+    bool downKeyPressed;
+    bool enterKeyPressed;
+    bool escKeyPressed;
+    bool lastMousePressed;
+    
+    // Note: ESC cooldown is managed by Game class globally
+    
+    // TTF Font
+    TTF_Font* titleFont;
+    TTF_Font* menuFont;
+    
+    // Colors
+    SDL_Color titleColor;
+    SDL_Color normalColor;
+    SDL_Color selectedColor;
+    SDL_Color disabledColor;
+    
+    // Layout
+    int titleY;
+    int menuStartY;
+    int menuSpacing;
+};


### PR DESCRIPTION
Исходный промпт:

> `@CODE_PATTERNS.md @GAME_ARCHITECTURE.md 
> Давай добавим основное меню в игру.
> Точка входа в меню:
> - Старт игры
> - После проигрыша
> - Нажатие ESC
> 
> Кнопки в меню:
> - Продолжить (только при входе через ESC)
> - Новая игра
> - Выход
> 
> Учитывай игровую логику и основной флоу. Нужно будет внедриться в него`

Доработка:

> В данный момент мешают две проблемы:
> 1. клик мыши работает как Enter - запускает выбранную опцию на любом месте экрана
> 2. Esc прожимается несколько раз при одном нажатии. Иногда меню открывается и тут же закрывается во время игры
> 
> Давай сделаем две доработки, чтобы меню работало приятнее:
> - Клик мышки должен срабатывать на кнопке, только если мышь находится в ее области.
> - Экранировать множественное нажате на ESC. Возможно, поставить кулдаун на нажатие, но тут смотри как лучше@CODE_PATTERNS.md @GAME_ARCHITECTURE.md 

И потом еще пару запросов борол кулдаун и Esc потому что он ерунду делал